### PR TITLE
Use underscore for basenames to accomodate multi-word resource names

### DIFF
--- a/lib/aptible/resource/base.rb
+++ b/lib/aptible/resource/base.rb
@@ -32,7 +32,7 @@ module Aptible
       end
 
       def self.basename
-        name.split('::').last.downcase.pluralize
+        name.split('::').last.underscore.pluralize
       end
 
       def self.all(options = {})

--- a/lib/aptible/resource/version.rb
+++ b/lib/aptible/resource/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module Resource
-    VERSION = '0.2.6'
+    VERSION = '0.2.7'
   end
 end


### PR DESCRIPTION
cc @fancyremarker 

Prior to this fix `Aptible::Auth::SSHKey.basename == 'sshkeys'`
