### PR TITLE
Add Resource.embeds_many for embedded responses

### DIFF
--- a/lib/aptible/resource/base.rb
+++ b/lib/aptible/resource/base.rb
@@ -81,6 +81,11 @@ module Aptible
       end
       # rubocop:enable PredicateName
 
+      def self.embeds_many(relation)
+        define_embeds_many_getter(relation)
+        define_has_many_setter(relation)
+      end
+
       def self.field(name, options = {})
         define_method name do
           self.class.cast_field(attributes[name], options[:type])
@@ -116,6 +121,12 @@ module Aptible
           elsif links[relation]
             instance_variable_set("@#{relation}", links[relation].entries)
           end
+        end
+      end
+
+      def self.define_embeds_many_getter(relation)
+        define_method relation do
+          objects[relation].entries
         end
       end
 

--- a/lib/hyper_resource/adapter/hal_json.rb
+++ b/lib/hyper_resource/adapter/hal_json.rb
@@ -50,6 +50,7 @@ class HyperResource
                          :headers => rsrc.headers,
                          :namespace => rsrc.namespace)
               r.body = collection
+              r = classify(collection, r)
               objs[name] = apply(collection, r)
             else
               objs[name] = collection.map do |obj|


### PR DESCRIPTION
This allows relations to be either embedded or referenced as links, but for the corresponding objects to be treated identically in either case. For example, if we want to load `app.services` without an additional HTTP request, we can just add `services` to the `_embedded` section of the HAL document.
