### PR TITLE
Add pagination handling to Resource::Base.all

### DIFF
--- a/aptible-resource.gemspec
+++ b/aptible-resource.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = `git ls-files`.split($RS)
-  spec.test_files    = spec.files.grep(/^spec\//)
+  spec.test_files    = spec.files.grep(%r{^spec\/})
   spec.require_paths = ['lib']
 
   # HyperResource dependencies

--- a/lib/aptible/resource/base.rb
+++ b/lib/aptible/resource/base.rb
@@ -35,11 +35,18 @@ module Aptible
         name.split('::').last.underscore.pluralize
       end
 
+      # rubocop:disable AbcSize
       def self.all(options = {})
-        resource = find_by_url(collection_href, options)
+        resource = find_by_url(options[:href] || collection_href, options)
         return [] unless resource
-        resource.send(basename).entries
+        if resource.links.key?('next')
+          options[:href] = resource.links['next'].href
+          resource.send(basename).entries + all(options)
+        else
+          resource.send(basename).entries
+        end
       end
+      # rubocop: enable AbcSize
 
       def self.where(options = {})
         params = options.except(:token, :root, :namespace, :headers)

--- a/spec/aptible/resource/base_spec.rb
+++ b/spec/aptible/resource/base_spec.rb
@@ -32,6 +32,7 @@ describe Aptible::Resource::Base do
 
     before do
       collection.stub(:mainframes) { [mainframe] }
+      collection.stub(:links) { Hash.new }
       Api::Mainframe.any_instance.stub(:find_by_url) { collection }
     end
 
@@ -48,6 +49,22 @@ describe Aptible::Resource::Base do
       options = { token: 'token' }
       expect(klass).to receive(:new).with(options).and_return klass.new
       Api::Mainframe.all(options)
+    end
+
+    describe 'when paginated' do
+      before do
+        page = double('page')
+        allow(page).to receive(:href).and_return(
+          '/next/page', '/next/page', '/next/page'
+        )
+        allow(collection).to receive(:links).and_return(
+          { 'next' => page }, { 'next' => page }, {}
+        )
+      end
+
+      it 'should collect entries on all pages' do
+        expect(Api::Mainframe.all).to eq [mainframe] + [mainframe]
+      end
     end
   end
 


### PR DESCRIPTION
This fixes half of a bug we're seeing in the aptible cli. 

The default pagination on `https://api.aptible.com/databases` only shows the 40 databases per page - we happen to have 42 databases, so two of our databases are inaccessible through the cli (including creating tunnels).

The problem:
``` ruby
Aptible::Api::Database.all(token: token).count
=> 40
Aptible::Api::Account.all(token: token).collect { |account| account.databases }.flatten.count
=> 42  # separating by account sidesteps the limit
```

This PR makes the `Resource::Base.all` method page through all pages of a resource and collect the entries. I've included tests and have also loaded it into aptible-api locally to verify that `Database.all` returns all 42 of our databases. 

(There's still a problem on the backend too, in the service that creates the tunnels - looks like it's using the same api client and having the same paging problem)

Let me know if I need to change anything or if I can to do anything else to help this along!