### PR TITLE
Remove special type field from adapter

### DIFF
--- a/lib/aptible/resource/adapter.rb
+++ b/lib/aptible/resource/adapter.rb
@@ -5,9 +5,7 @@ module Aptible
         def get_data_type_from_object(object)
           return nil unless object
 
-          # TODO: Only reference _type
-          # See https://github.com/aptible/auth.aptible.com/issues/61
-          return nil unless (type = object['_type'] || object['type'])
+          return nil unless (type = object['_type'])
           if type.respond_to?(:camelize)
             type.camelize
           else

--- a/lib/aptible/resource/version.rb
+++ b/lib/aptible/resource/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module Resource
-    VERSION = '0.3.0'
+    VERSION = '0.3.1'
   end
 end

--- a/spec/aptible/resource/base_spec.rb
+++ b/spec/aptible/resource/base_spec.rb
@@ -226,7 +226,7 @@ describe Aptible::Resource::Base do
 
       it 'should have errors present on error' do
         mainframes_link.stub(:create) { fail hyperresource_exception }
-        expect(subject.create_mainframe.errors.any?).to be_true
+        expect(subject.create_mainframe.errors.any?).to be true
       end
 
       it 'should return the object in the event of successful creation' do
@@ -236,7 +236,7 @@ describe Aptible::Resource::Base do
 
       it 'should have no errors on successful creation' do
         mainframes_link.stub(:create) { mainframe }
-        expect(subject.create_mainframe.errors.any?).to be_false
+        expect(subject.create_mainframe.errors.any?).to be false
       end
     end
 
@@ -258,7 +258,7 @@ describe Aptible::Resource::Base do
   context '.field' do
     it 'should define a method for the field' do
       Api.field :foo, type: String
-      expect(subject.respond_to?(:foo)).to be_true
+      expect(subject.respond_to?(:foo)).to be true
     end
 
     it 'should return the raw attribute' do
@@ -282,7 +282,7 @@ describe Aptible::Resource::Base do
     it 'should add a ? helper if Boolean' do
       Api.field :awesome, type: Aptible::Resource::Boolean
       subject.stub(:attributes) { { awesome: 'true' } }
-      expect(subject.awesome?).to be_true
+      expect(subject.awesome?).to be true
     end
   end
 end


### PR DESCRIPTION
Remove special `type` field from adapter; use `_type` if there is a need to (de)serialize to a specific type.

cc @fancyremarker @sandersonet 