### PR TITLE
Add default timeout at 10 seconds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+
 rvm:
   - 2.0.0
   - jruby

--- a/lib/aptible/resource/base.rb
+++ b/lib/aptible/resource/base.rb
@@ -183,6 +183,16 @@ module Aptible
         end
       end
 
+      def self.faraday_options
+        # Default Faraday options. May be overridden by passing
+        # faraday_options to the initializer.
+        {
+          request: {
+            open_timeout: 10
+          }
+        }
+      end
+
       # rubocop:disable MethodLength
       def initialize(options = {})
         if options.is_a?(Hash)

--- a/lib/aptible/resource/version.rb
+++ b/lib/aptible/resource/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module Resource
-    VERSION = '0.3.1'
+    VERSION = '0.3.2'
   end
 end

--- a/spec/aptible/resource/network_spec.rb
+++ b/spec/aptible/resource/network_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe Aptible::Resource::Base, slow: true do
+  subject { Api.new(root: 'http://10.255.255.1/') }
+
+  it 'should time out by default after a reasonable delay' do
+    # Faraday throws different kinds of errors depending on whether
+    # Net::OpenTimeout is defined, so let's check for this
+    # https://github.com/lostisland/faraday/issues/561
+    e = Faraday::Error::TimeoutError
+    e = Faraday::Error::ConnectionFailed if defined? Net::OpenTimeout
+
+    expect do
+      Timeout.timeout(15) { subject.all }
+    end.to raise_error(e, 'execution expired')
+  end
+end


### PR DESCRIPTION
This will cause requests to time out if it takes longer than 10 seconds to establish a connection.

cc @fancyremarker 