### PR TITLE
Extend pagination support to has_many resources

### DIFF
--- a/lib/aptible/resource/base.rb
+++ b/lib/aptible/resource/base.rb
@@ -41,9 +41,9 @@ module Aptible
         return [] unless resource
         if resource.links.key?('next')
           options[:href] = resource.links['next'].href
-          resource.send(basename).entries + all(options)
+          resource.entries + all(options)
         else
-          resource.send(basename).entries
+          resource.entries
         end
       end
       # rubocop: enable AbcSize
@@ -126,7 +126,9 @@ module Aptible
           if (memoized = instance_variable_get("@#{relation}"))
             memoized
           elsif links[relation]
-            instance_variable_set("@#{relation}", links[relation].entries)
+            depaginated = self.class.all(href: links[relation].base_href,
+                                         headers: headers)
+            instance_variable_set("@#{relation}", depaginated)
           end
         end
       end

--- a/spec/aptible/resource/base_spec.rb
+++ b/spec/aptible/resource/base_spec.rb
@@ -31,7 +31,7 @@ describe Aptible::Resource::Base do
     let(:collection) { double 'Api' }
 
     before do
-      collection.stub(:mainframes) { [mainframe] }
+      collection.stub(:entries) { [mainframe] }
       collection.stub(:links) { Hash.new }
       Api::Mainframe.any_instance.stub(:find_by_url) { collection }
     end
@@ -51,7 +51,7 @@ describe Aptible::Resource::Base do
       Api::Mainframe.all(options)
     end
 
-    describe 'when paginated' do
+    context 'when paginated' do
       before do
         page = double('page')
         allow(page).to receive(:href).and_return(
@@ -210,6 +210,8 @@ describe Aptible::Resource::Base do
     before { Api.has_many :mainframes }
     before { subject.stub(:loaded) { true } }
     before { subject.stub(:links) { { mainframes: mainframes_link } } }
+    before { mainframes_link.stub(:entries) { [mainframe] } }
+    before { mainframes_link.stub(:base_href) { '/mainframes' } }
 
     describe '#create_#{relation}' do
       it 'should populate #errors in the event of an error' do
@@ -251,6 +253,14 @@ describe Aptible::Resource::Base do
       it 'should return the object in the event of successful creation' do
         mainframes_link.stub(:create) { mainframe }
         expect(subject.create_mainframe!({})).to eq mainframe
+      end
+    end
+
+    describe '#{relation}s' do
+      it 'should defer to self.class.all' do
+        expect(subject.class).to receive(:all).with(href: '/mainframes',
+                                                    headers: subject.headers)
+        subject.mainframes
       end
     end
   end


### PR DESCRIPTION
This extends the pagination support from #22 for Resource::Base.all to relations defined on Resource::Base objects by a has_many definition. For example:

    Aptible::Api::Account#services

Fixes aptible/aptible-cli#136

cc: @gib