### PR TITLE
Retry requests that fail with a timeout

### DIFF
--- a/aptible-resource.gemspec
+++ b/aptible-resource.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   # HyperResource dependencies
   spec.add_dependency 'uri_template', '>= 0.5.2'
-  spec.add_dependency 'faraday',      '>= 0.8.6'
+  spec.add_dependency 'faraday',      '~> 0.9.2'
   spec.add_dependency 'json'
 
   spec.add_dependency 'fridge'
@@ -32,4 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 2.0'
   spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'webmock'
 end

--- a/lib/aptible/resource/base.rb
+++ b/lib/aptible/resource/base.rb
@@ -12,6 +12,9 @@ require 'aptible/resource/adapter'
 require 'aptible/resource/errors'
 require 'aptible/resource/boolean'
 
+# Open errors that make sense
+require 'aptible/resource/ext/faraday'
+
 module Aptible
   module Resource
     # rubocop:disable ClassLength

--- a/lib/aptible/resource/ext/faraday.rb
+++ b/lib/aptible/resource/ext/faraday.rb
@@ -1,0 +1,5 @@
+Faraday::Adapter::NetHttp.class_eval do |cls|
+  # Work around https://github.com/lostisland/faraday/issues/561 by treating
+  # connection timeouts as... timeouts.
+  cls::NET_HTTP_EXCEPTIONS.delete Net::OpenTimeout if defined?(Net::OpenTimeout)
+end

--- a/lib/hyper_resource/modules/http.rb
+++ b/lib/hyper_resource/modules/http.rb
@@ -78,12 +78,18 @@ class HyperResource
         }.to_json)
         return Thread.current[key] if Thread.current[key]
 
-        fc = Faraday.new(self.faraday_options.merge(:url => url))
-        fc.headers.merge!('User-Agent' => "HyperResource #{HyperResource::VERSION}")
-        fc.headers.merge!(self.headers || {})
-        if ba=self.auth[:basic]
-          fc.basic_auth(*ba)
+        fc = Faraday.new(self.faraday_options.merge(:url => url)) do |builder|
+          builder.headers.merge!('User-Agent' => "HyperResource #{HyperResource::VERSION}")
+          builder.headers.merge!(self.headers || {})
+          if (ba = self.auth[:basic])
+            builder.basic_auth(*ba)
+          end
+
+          builder.request :url_encoded
+          builder.request :retry
+          builder.adapter Faraday.default_adapter
         end
+
         Thread.current[key] = fc
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,3 +12,7 @@ end
 
 # Require library up front
 require 'aptible/resource'
+
+# Webmock
+require 'webmock/rspec'
+WebMock.allow_net_connect!


### PR DESCRIPTION
This enables the default Farday retry middleware in order to retry
requests that time out: https://github.com/lostisland/faraday/blob/v0.9.2/lib/faraday/request/retry.rb

Requests are retried up to 2 times if they time out and are an
idempotent method (`[:delete, :get, :head, :options, :put]`).

This includes a monkey-patch of Faraday to ensure connection timeouts
are in fact interpreted as timeouts so they can be retried.

---

cc @fancyremarker 