### PR TITLE
Add ability to use query params in find method

### DIFF
--- a/lib/aptible/resource/base.rb
+++ b/lib/aptible/resource/base.rb
@@ -58,7 +58,10 @@ module Aptible
       end
 
       def self.find(id, options = {})
-        find_by_url("#{collection_href}/#{id}", options)
+        params = options.except(:token, :root, :namespace, :headers)
+        params = normalize_params(params)
+        params = params.empty? ? '' : '?' + params.to_query
+        find_by_url("#{collection_href}/#{id}#{params}", options)
       end
 
       def self.find_by_url(url, options = {})

--- a/lib/aptible/resource/version.rb
+++ b/lib/aptible/resource/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module Resource
-    VERSION = '0.3.4'
+    VERSION = '0.3.5'
   end
 end

--- a/spec/aptible/resource/base_spec.rb
+++ b/spec/aptible/resource/base_spec.rb
@@ -24,6 +24,12 @@ describe Aptible::Resource::Base do
       expect(Api::Mainframe).to receive(:find_by_url).with url, {}
       Api::Mainframe.find(42)
     end
+
+    it 'should call find_by_url with query params' do
+      url = '/mainframes/42?test=123'
+      expect(Api::Mainframe).to receive(:find_by_url).with url, test: 123
+      Api::Mainframe.find(42, test: 123)
+    end
   end
 
   describe '.all' do


### PR DESCRIPTION
This commit adds the ability to set optional query params on
`Aptible::Resource::Base::find`.

cc @fancyremarker 