### PR TITLE
Add Base.each_page

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,6 @@ sudo: false
 
 rvm:
   - 2.0.0
-  - jruby
+  - 2.1.0
+  - 2.2.0
+  - jruby-9.0.5.0

--- a/lib/aptible/resource/base.rb
+++ b/lib/aptible/resource/base.rb
@@ -100,7 +100,7 @@ module Aptible
 
       # rubocop:disable PredicateName
       def self.has_many(relation)
-        define_has_many_getter(relation)
+        define_has_many_getters(relation)
         define_has_many_setter(relation)
       end
       # rubocop:enable PredicateName
@@ -137,7 +137,9 @@ module Aptible
       end
       # rubocop:enable PredicateName
 
-      def self.define_has_many_getter(relation)
+      # rubocop:disable MethodLength
+      # rubocop:disable AbcSize
+      def self.define_has_many_getters(relation)
         define_method relation do
           get unless loaded
           if (memoized = instance_variable_get("@#{relation}"))
@@ -148,7 +150,17 @@ module Aptible
             instance_variable_set("@#{relation}", depaginated)
           end
         end
+
+        define_method "each_#{relation.to_s.singularize}" do |&block|
+          return if block.nil?
+          self.class.each_page(href: links[relation].base_href,
+                               headers: headers) do |page|
+            page.each { |entry| block.call entry }
+          end
+        end
       end
+      # rubocop:enable AbcSize
+      # rubocop:enable MethodLength
 
       def self.embeds_one(relation)
         define_method relation do


### PR DESCRIPTION
Unlike Base.all, this allowss consumer to exit the block as soon as they
have collected everything they need. It's a lower-level method, but it
can be useful when the collection is expected to be lengthy (e.g.
operations, or backups), but only a small initial subset is needed.

---

cc @fancyremarker . 

FWIW, I'm not a huge fan of my implementation here, which from a consumer perspective isn't ideally usable (the consumer needs to call `Aptible::Api::Base.each_page(href: ..., token: ...)`), but I think it's the best we can do considering how the API client is currently architectured (that is, considering that related lists are actually naïve *lists*, not an object that could implement those methods).