### PR TITLE
Add `retry_coordinator `, `user_agent` configuration

### DIFF
--- a/aptible-resource.gemspec
+++ b/aptible-resource.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'fridge'
   spec.add_dependency 'activesupport', '~> 4.0'
+  spec.add_dependency 'gem_config', '~> 0.3.1'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'aptible-tasks'

--- a/lib/aptible/resource.rb
+++ b/lib/aptible/resource.rb
@@ -1,7 +1,20 @@
 require 'aptible/resource/version'
 require 'aptible/resource/base'
+require 'aptible/resource/default_retry_coordinator'
+require 'gem_config'
 
 module Aptible
   module Resource
+    include GemConfig::Base
+
+    with_configuration do
+      has :retry_coordinator_class,
+          classes: [Class],
+          default: DefaultRetryCoordinator
+
+      has :user_agent,
+          classes: [String],
+          default: "aptible-resource #{Aptible::Resource::VERSION}"
+    end
   end
 end

--- a/lib/aptible/resource/base.rb
+++ b/lib/aptible/resource/base.rb
@@ -15,7 +15,6 @@ require 'aptible/resource/boolean'
 # Open errors that make sense
 require 'aptible/resource/ext/faraday'
 
-# rubocop:disable Style/SignalException
 module Aptible
   module Resource
     # rubocop:disable ClassLength
@@ -245,11 +244,11 @@ module Aptible
       end
 
       def namespace
-        fail 'Resource server namespace must be defined by subclass'
+        raise 'Resource server namespace must be defined by subclass'
       end
 
       def root_url
-        fail 'Resource server root URL must be defined by subclass'
+        raise 'Resource server root URL must be defined by subclass'
       end
 
       def find_by_url(url_or_href)
@@ -310,5 +309,3 @@ module Aptible
     # rubocop:enable ClassLength
   end
 end
-
-# rubocop:enable Style/SignalException

--- a/lib/aptible/resource/default_retry_coordinator.rb
+++ b/lib/aptible/resource/default_retry_coordinator.rb
@@ -1,0 +1,15 @@
+module Aptible
+  module Resource
+    class DefaultRetryCoordinator
+      attr_reader :resource
+
+      def initialize(resource)
+        @resource = resource
+      end
+
+      def retry?(_error)
+        false
+      end
+    end
+  end
+end

--- a/lib/hyper_resource.rb
+++ b/lib/hyper_resource.rb
@@ -199,6 +199,7 @@ public
                    :headers         => self.headers,
                    :namespace       => self.namespace,
                    :faraday_options => self.faraday_options,
+                   :token           => self.token,
                    :href            => href)
   end
 

--- a/lib/hyper_resource/adapter/hal_json.rb
+++ b/lib/hyper_resource/adapter/hal_json.rb
@@ -48,6 +48,7 @@ class HyperResource
             if collection.is_a? Hash
               r = rc.new(:root => rsrc.root,
                          :headers => rsrc.headers,
+                         :token => rsrc.token,
                          :namespace => rsrc.namespace)
               r.body = collection
               r = classify(collection, r)
@@ -56,6 +57,7 @@ class HyperResource
               objs[name] = collection.map do |obj|
                 r = rc.new(:root => rsrc.root,
                            :headers => rsrc.headers,
+                           :token => rsrc.token,
                            :namespace => rsrc.namespace)
                 r.body = obj
                 r = classify(obj, r)
@@ -73,8 +75,10 @@ class HyperResource
           klass = rsrc.class.namespaced_class(type_name, namespace)
 
           if klass
+            # TODO: Why does this not use klass.new(rsrc)?
             rsrc = klass.new(:root => rsrc.root,
                              :headers => rsrc.headers,
+                             :token => rsrc.token,
                              :namespace => rsrc.namespace)
             rsrc.body = resp
           end

--- a/lib/hyper_resource/modules/internal_attributes.rb
+++ b/lib/hyper_resource/modules/internal_attributes.rb
@@ -38,6 +38,7 @@ module HyperResource::Modules
           :namespace,
           :adapter,
           :faraday_options,
+          :token,
 
           :request,
           :response,

--- a/spec/aptible/resource/base_spec.rb
+++ b/spec/aptible/resource/base_spec.rb
@@ -1,6 +1,5 @@
 require 'spec_helper'
 
-# rubocop:disable Style/SignalException
 describe Aptible::Resource::Base do
   let(:hyperresource_exception) { HyperResource::ResponseError.new('403') }
   let(:error_response) { double 'Faraday::Response' }
@@ -36,7 +35,7 @@ describe Aptible::Resource::Base do
         allow_any_instance_of(klass).to receive(:find_by_url) do |u, _|
           calls << u
           page = pages[u]
-          fail "Accessed unexpected URL #{u}" if page.nil?
+          raise "Accessed unexpected URL #{u}" if page.nil?
           page
         end
       end
@@ -147,14 +146,14 @@ describe Aptible::Resource::Base do
     end
 
     it 'should populate #errors in the event of an error' do
-      mainframes_link.stub(:create) { fail hyperresource_exception }
+      mainframes_link.stub(:create) { raise hyperresource_exception }
       mainframe = Api::Mainframe.create
       expect(mainframe.errors.messages).to eq(base: 'Forbidden')
       expect(mainframe.errors.full_messages).to eq(['Forbidden'])
     end
 
     it 'should return a Base-classed resource on error' do
-      mainframes_link.stub(:create) { fail hyperresource_exception }
+      mainframes_link.stub(:create) { raise hyperresource_exception }
       expect(Api::Mainframe.create).to be_a Api::Mainframe
     end
 
@@ -172,7 +171,7 @@ describe Aptible::Resource::Base do
     before { mainframes_link.stub(:create) { mainframe } }
 
     it 'should pass through any exceptions' do
-      mainframes_link.stub(:create) { fail hyperresource_exception }
+      mainframes_link.stub(:create) { raise hyperresource_exception }
       expect do
         Api::Mainframe.create!
       end.to raise_error HyperResource::ResponseError
@@ -225,14 +224,14 @@ describe Aptible::Resource::Base do
 
   describe '#update' do
     it 'should populate #errors in the event of an error' do
-      HyperResource.any_instance.stub(:put) { fail hyperresource_exception }
+      HyperResource.any_instance.stub(:put) { raise hyperresource_exception }
       subject.update({})
       expect(subject.errors.messages).to eq(base: 'Forbidden')
       expect(subject.errors.full_messages).to eq(['Forbidden'])
     end
 
     it 'should return false in the event of an error' do
-      HyperResource.any_instance.stub(:put) { fail hyperresource_exception }
+      HyperResource.any_instance.stub(:put) { raise hyperresource_exception }
       expect(subject.update({})).to eq false
     end
 
@@ -244,7 +243,7 @@ describe Aptible::Resource::Base do
 
   describe '#update!' do
     it 'should populate #errors in the event of an error' do
-      HyperResource.any_instance.stub(:put) { fail hyperresource_exception }
+      HyperResource.any_instance.stub(:put) { raise hyperresource_exception }
       begin
         subject.update!({})
       rescue
@@ -256,7 +255,7 @@ describe Aptible::Resource::Base do
     end
 
     it 'should pass through any exceptions' do
-      HyperResource.any_instance.stub(:put) { fail hyperresource_exception }
+      HyperResource.any_instance.stub(:put) { raise hyperresource_exception }
       expect do
         subject.update!({})
       end.to raise_error HyperResource::ResponseError
@@ -280,19 +279,19 @@ describe Aptible::Resource::Base do
 
     describe '#create_#{relation}' do
       it 'should populate #errors in the event of an error' do
-        mainframes_link.stub(:create) { fail hyperresource_exception }
+        mainframes_link.stub(:create) { raise hyperresource_exception }
         mainframe = subject.create_mainframe({})
         expect(mainframe.errors.messages).to eq(base: 'Forbidden')
         expect(mainframe.errors.full_messages).to eq(['Forbidden'])
       end
 
       it 'should return a Base-classed resource on error' do
-        mainframes_link.stub(:create) { fail hyperresource_exception }
+        mainframes_link.stub(:create) { raise hyperresource_exception }
         expect(subject.create_mainframe.class).to eq Aptible::Resource::Base
       end
 
       it 'should have errors present on error' do
-        mainframes_link.stub(:create) { fail hyperresource_exception }
+        mainframes_link.stub(:create) { raise hyperresource_exception }
         expect(subject.create_mainframe.errors.any?).to be true
       end
 
@@ -309,7 +308,7 @@ describe Aptible::Resource::Base do
 
     describe '#create_#{relation}!' do
       it 'should pass through any exceptions' do
-        mainframes_link.stub(:create) { fail hyperresource_exception }
+        mainframes_link.stub(:create) { raise hyperresource_exception }
         expect do
           subject.create_mainframe!({})
         end.to raise_error HyperResource::ResponseError
@@ -389,5 +388,3 @@ describe Aptible::Resource::Base do
     end
   end
 end
-
-# rubocop:enable Style/SignalException

--- a/spec/aptible/resource/network_spec.rb
+++ b/spec/aptible/resource/network_spec.rb
@@ -9,12 +9,6 @@ describe Aptible::Resource::Base do
   subject { Api.new(root: "http://#{domain}") }
 
   context 'with mock connections' do
-    around do |example|
-      WebMock.disable_net_connect!
-      example.run
-      WebMock.allow_net_connect!
-    end
-
     it 'should retry timeout errors' do
       stub_request(:get, domain)
         .to_timeout.then
@@ -34,6 +28,12 @@ describe Aptible::Resource::Base do
   end
 
   context 'without connections' do
+    around do |example|
+      WebMock.allow_net_connect!
+      example.run
+      WebMock.disable_net_connect!
+    end
+
     it 'default to 10 seconds of timeout and retry 3 times' do
       # This really relies on how exactly MRI implements Net::HTTP open timeouts
       skip 'MRI implementation-specific' if RUBY_PLATFORM == 'java'

--- a/spec/fixtures/api.rb
+++ b/spec/fixtures/api.rb
@@ -1,6 +1,9 @@
 require 'aptible/resource'
 
 class Api < Aptible::Resource::Base
+  has_many :mainframes
+  embeds_one :best_mainframe
+
   def namespace
     'Api'
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,4 +15,9 @@ require 'aptible/resource'
 
 # Webmock
 require 'webmock/rspec'
-WebMock.allow_net_connect!
+WebMock.disable_net_connect!
+
+RSpec.configure do |config|
+  config.before { Aptible::Resource.configuration.reset }
+  config.before { WebMock.reset! }
+end


### PR DESCRIPTION
~~`retry_proc` is meant to be used by clients to e.g. update the token when
it expires, and can be used to instruct aptible-api to retry the request
at the application layer (connection layer issues will be retried by
Faraday).~~

`retry_coordinator` is meant to be used by clients to e.g. update the
token when it expires, or to instruct aptible-api to retry the request
at the application layer (connection layer issues will be retried by
Faraday). This might be useful if we're hitting a Bad Gateway issue that
we'd like to retry (since we know that in this case, the API didn't
actually *see* the request).

`user_agent` is meant to let the client advertise who they are. This will
presumably be useful for e.g. the CLI to advertise its version, or
Sweetness (this could also be made more specific, including the
Sweetness stack, etc.).

This also tries to address several gravely misguided architectural
decisions in HyperResource, like caching connections in a thread pool
that's never cleaned (!), with keys that are so specific that they're
unlikely to be ever be reused (essentially making the thread pool
useless), or updating attributes on an object with a response that might
turn out to be invalid.


--

cc @blakepettersson 
fyi @fancyremarker 