### PR TITLE
Add token expired exception

### DIFF
--- a/lib/hyper_resource/exceptions.rb
+++ b/lib/hyper_resource/exceptions.rb
@@ -36,5 +36,6 @@ class HyperResource
 
   class ClientError < ResponseError; end
   class ServerError < ResponseError; end
+  class TokenExpiredError < ClientError; end
 end
 

--- a/lib/hyper_resource/modules/http.rb
+++ b/lib/hyper_resource/modules/http.rb
@@ -118,6 +118,11 @@ class HyperResource
         elsif status / 100 == 3
           raise 'HyperResource does not handle redirects'
         elsif status / 100 == 4
+          if body && body['error'] == 'expired_token'
+            raise HyperResource::TokenExpiredError.new(status.to_s,
+                                                       response: response,
+                                                       body: body)
+          end
           raise HyperResource::ClientError.new(status.to_s,
                                                response: response,
                                                body: body)


### PR DESCRIPTION
This commit adds a subclass of `HyperResource::ClientError` for token
expires. So far, this is only intended to be used to shut Sentry up since
having a bunch of token expiry errors doesn't add much value, but at
the same time we do want to know about legitimate
`HyperResource::ClientError`s.

cc @krallin 