### PR TITLE
Remove activesupport pin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'activesupport', '~> 4.0'
+
 # Specify your gem's dependencies in aptible-resource.gemspec
 gemspec

--- a/aptible-resource.gemspec
+++ b/aptible-resource.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'json'
 
   spec.add_dependency 'fridge'
-  spec.add_dependency 'activesupport', '~> 4.0'
+  spec.add_dependency 'activesupport', '>= 4.0', '< 6.0'
   spec.add_dependency 'gem_config', '~> 0.3.1'
 
   spec.add_development_dependency 'bundler', '~> 1.3'


### PR DESCRIPTION
We only need this when installing dependencies in test (so it can go in
the Gemfile), whereas having it in the gemspec prevents users of this
gem from upgrading to Rails 5.

cc @fancyremarker @blakepettersson 