### PR TITLE
Relax Faraday dependency

### DIFF
--- a/aptible-resource.gemspec
+++ b/aptible-resource.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   # HyperResource dependencies
   spec.add_dependency 'uri_template', '>= 0.5.2'
-  spec.add_dependency 'faraday',      '~> 0.9.2'
+  spec.add_dependency 'faraday',      '>= 0.9.2', '< 0.14'
   spec.add_dependency 'json'
 
   spec.add_dependency 'fridge'


### PR DESCRIPTION
There appear to have only been minor feature additions and bug fixes in
Faraday between 0.9.2 and the current version (0.13.1), and we no longer
depend on Faraday internals (or much of Faraday) as of #33.

There's no particular urgency in upgrading ourselves, but pinning to
v0.9.x prevents customers from installing `aptible-resource` alongside
other gems that dependent on a more recent version of Faraday.

---

cc @fancyremarker @UserNotFound 