### PR TITLE
Fix HyperResource#method_missing block handling

### DIFF
--- a/lib/hyper_resource.rb
+++ b/lib/hyper_resource.rb
@@ -130,14 +130,14 @@ public
   ## in this resource.  Returns nil on failure.
   def [](i)
     get unless loaded
-    self.objects.first[1][i] rescue nil
+    self.objects.first[1][i]
   end
 
   ## Iterates over the objects in the first collection of embedded objects
   ## in this resource.
   def each(&block)
     get unless loaded
-    self.objects.first[1].each(&block) rescue nil
+    self.objects.first[1].each(&block)
   end
 
   #### Magic

--- a/lib/hyper_resource/link.rb
+++ b/lib/hyper_resource/link.rb
@@ -53,7 +53,7 @@ class HyperResource::Link
 
   ## If we were called with a method we don't know, load this resource
   ## and pass the message along.  This achieves implicit loading.
-  def method_missing(method, *args)
-    self.get.send(method, *args)
+  def method_missing(method, *args, &block)
+    self.get.send(method, *args, &block)
   end
 end

--- a/spec/aptible/resource/base_spec.rb
+++ b/spec/aptible/resource/base_spec.rb
@@ -646,4 +646,35 @@ describe Aptible::Resource::Base do
       expect(m.token).to eq('bar')
     end
   end
+
+  context 'last-minute fetching' do
+    subject { Api.new(root: 'http://foo.com') }
+
+    it 'should support enumerable methods' do
+      index = {
+        _links: {
+          some_items: { href: 'http://foo.com/some_items' }
+        }
+      }
+
+      some_items = {
+        _embedded: {
+          some_items: [
+            { id: 1, handle: 'foo' },
+            { id: 2, handle: 'bar' },
+            { id: 3, handle: 'qux' }
+          ]
+        }
+      }
+
+      stub_request(:get, 'foo.com')
+        .to_return(body: index.to_json, status: 200)
+
+      stub_request(:get, 'foo.com/some_items')
+        .to_return(body: some_items.to_json, status: 200)
+
+      bar = subject.some_items.find { |m| m.id == 2 }
+      expect(bar.handle).to eq('bar')
+    end
+  end
 end


### PR DESCRIPTION
HyperResource does not pass through the block in `method_missing` for a
link. As a result, this type of call fails (it ignores the blocks and
returns an `Enumerator`):

```
api = Aptible::Api::Resource.new(token: token)
acct = api.accounts.find { |a| a.handle == 'foo' }
```

We don't normally call this too often since we have our `has_many`
methods defined on the resources we query, but the above example is
actually a useful use case, which should be supported.

I've also removed a few exception-silencing statements in the process.

---

cc @fancyremarker 